### PR TITLE
fselect: Add version 1.11.0

### DIFF
--- a/bucket/.gitkeep
+++ b/bucket/.gitkeep
@@ -1,1 +1,0 @@
-Some text to keep CRLF for passing tests without manifest

--- a/bucket/fselect.json
+++ b/bucket/fselect.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.7.1",
+    "description": "Find files with SQL-like queries",
+    "homepage": "https://github.com/jhspetersson/fselect",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jhspetersson/fselect/releases/download/0.7.1/fselect-x86_64-win.zip",
+            "hash": "895b41f2b8f592ebbe3ca44bc79d1f52959e2e01ae77974b8232c6b391443c4d"
+        }
+    },
+    "bin": "fselect.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jhspetersson/fselect/releases/download/$version/fselect-x86_64-win.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Find files with SQL-like queries

While it doesn't tend to fully replace traditional find and ls, fselect has these nice features:

- SQL-like (not real SQL, but highly relaxed!) grammar easily understandable by humans
- complex queries
- aggregate, statistics, date, and other functions
- search within archives
- .gitignore, .hgignore, and .dockerignore support (experimental)
- search by width and height of images, EXIF metadata
- search by MP3 info
- search by extended file attributes
- search by file hashes
- search by MIME type
- shortcuts to common file types
- interactive mode
- various output formatting (CSV, JSON, and others)