### PR TITLE
exe-explorer: Add version 3.3.0

### DIFF
--- a/bucket/exe-explorer.json
+++ b/bucket/exe-explorer.json
@@ -1,0 +1,36 @@
+{
+    "version": "3.3.0",
+    "description": "Reads and displays executable file properties and structure",
+    "homepage": "http://mitec.cz/exe.html",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://mitec.cz/exe.html#licence"
+    },
+    "url": "http://mitec.cz/Downloads/EXE.zip",
+    "hash": "4481bc013298414b0510ecf467fa44fcb7bd9798651a912ec328d993cab04a4a",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "EXE64.exe",
+                    "exe"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": [
+                [
+                    "EXE.exe",
+                    "exe"
+                ]
+            ]
+        }
+    },
+    "checkver": {
+        "url": "http://mitec.cz/Data/XML/data_downloads.xml",
+        "re": "MiTeC EXE Explorer 32/64 ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "http://mitec.cz/Downloads/EXE.zip"
+    }
+}

--- a/bucket/exe-explorer.json
+++ b/bucket/exe-explorer.json
@@ -28,7 +28,7 @@
     },
     "checkver": {
         "url": "http://mitec.cz/Data/XML/data_downloads.xml",
-        "re": "MiTeC EXE Explorer 32/64 ([\\d.]+)"
+        "regex": "MiTeC EXE Explorer 32/64 ([\\d.]+)"
     },
     "autoupdate": {
         "url": "http://mitec.cz/Downloads/EXE.zip"


### PR DESCRIPTION
This application is based on MiTeC Portable Executable Reader. It reads and displays executable file properties and structure. It is compatible with PE32 (Portable Executable), PE32+ (64bit), NE (Windows 3.x New Executable) and VxD (Windows 9x Virtual Device Driver) file types. .NET executables are supported too.