### PR TITLE
otter-browser: Add version 1.0.02

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ scoop install immuadmin immuclient immudb
 scoop install janet
 scoop install lagrange
 scoop install mpd
+scoop install otter-browser
 scoop install qmmp
 scoop install zecwallet-lite
 scoop install zecwallet-cli
@@ -54,6 +55,7 @@ scoop install zecwallet-cli
 | [Janet](https://janet-lang.org) | Janet is a lisp-like, embeddable, functional and imperative programming language and bytecode interpreter |
 | [Lagrange](https://github.com/skyjake/lagrange) | A desktop GUI client for browsing Geminispace |
 | [MPD](https://www.musicpd.org) | Famous MPD. It can play a variety of sound files while being controlled by its network protocol |
+| [Otter Browser](https://otter-browser.org/) | Browser that aims to recreate the best aspects of the classic Opera (12.x) UI using Qt5  |
 | [Qmmp](http://qmmp.ylsoftware.com) | Qt-based Multimedia Player |
 | [Zecwallet Lite](https://www.zecwallet.co) | ZCash Wallet Desktop Client application |
 | [Zecwallet CLI](https://www.zecwallet.co) | ZCash command-line interface utility |

--- a/bucket/otter-browser.json
+++ b/bucket/otter-browser.json
@@ -1,0 +1,41 @@
+{
+    "version": "1.0.02",
+    "description": "Browser that aims to recreate the best aspects of the classic Opera (12.x) UI using Qt5.",
+    "homepage": "https://otter-browser.org/",
+    "license": "GPL-3.0",
+    "architecture": {
+        "32bit": {
+            "url": "https://downloads.sourceforge.net/project/otter-browser/otter-browser-1.0.02/otter-browser-win32-1.0.02.7z",
+            "hash": "8df1cacf1c8ff6f69871fecfb183a10b82b6d0def50e22ec1def887dd753e257",
+            "extract_dir": "otter-browser-win32-1.0.02"
+        },
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/otter-browser/otter-browser-1.0.02/otter-browser-win64-1.0.02.7z",
+            "hash": "f1314bb20b4d100aa7c4bc4af2dd3d96265c4ce43e5622ddbfef53920df370b0",
+            "extract_dir": "otter-browser-win64-1.0.02"
+        }
+    },
+    "bin": "otter-browser.exe",
+    "shortcuts": [
+        [
+            "otter-browser.exe",
+            "Otter Browser"
+        ]
+    ],
+    "checkver": {
+        "url": "https://otter-browser.org/",
+        "regex": "([\\d.]+) release \\("
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/otter-browser/otter-browser-$version/otter-browser-win32-$version.7z",
+                "extract_dir": "otter-browser-win32-$version"
+            },
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/otter-browser/otter-browser-$version/otter-browser-win64-$version.7z",
+                "extract_dir": "otter-browser-win64-$version"
+            }
+        }
+    }
+}


### PR DESCRIPTION
A browser controlled by the user, not vice-versa

Otter Browser aims to recreate the best aspects of Opera 12 and to revive its spirit. We are focused on providing the powerful features power users want while keeping the browser fast and lightweight. We also learned from history and decided to release the browser under the GNU GPL v3.