### PR TITLE
netsurf: Add version 5313

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ scoop install jedit
 scoop install lagrange
 scoop install mpd
 scoop install mpg123
+scoop install netsurf
 scoop install otter-browser
 scoop install qmmp
 scoop install vlang
@@ -62,6 +63,7 @@ scoop install zecwallet-cli
 | [Lagrange](https://github.com/skyjake/lagrange) | A desktop GUI client for browsing Geminispace |
 | [MPD](https://www.musicpd.org) | Famous MPD. It can play a variety of sound files while being controlled by its network protocol |
 | [Mpg123](https://www.mpg123.org) | Fast console MPEG Audio Player and decoder library |
+| [NetSurf](https://www.netsurf-browser.org) | NetSurf is a multi-platform web browser |
 | [Otter Browser](https://otter-browser.org/) | Browser that aims to recreate the best aspects of the classic Opera (12.x) UI using Qt5  |
 | [Qmmp](http://qmmp.ylsoftware.com) | Qt-based Multimedia Player |
 | [Vlang](https://vlang.io) | Simple, fast, safe, compiled. For developing maintainable software |

--- a/bucket/netsurf.json
+++ b/bucket/netsurf.json
@@ -1,0 +1,23 @@
+{
+    "version": "5313",
+    "description": "NetSurf is a free, open source web browser",
+    "homepage": "https://www.netsurf-browser.org",
+    "license": "GPL-2.0",
+    "url": "https://ci.netsurf-browser.org/builds/windows/NetSurf-gcc-5313.exe#/dl.7z",
+    "hash": "e422f18cb730edeed2e8aa47a8fb85f3f76e19d149861ab455870ccd6132705e",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe\" -Recurse -Force",
+    "bin": "NetSurf.exe",
+    "shortcuts": [
+        [
+            "NetSurf.exe",
+            "NetSurt Browser"
+        ]
+    ],
+    "checkver": {
+        "url": "https://ci.netsurf-browser.org/builds/windows/LATEST",
+        "regex": "NetSurf-gcc-([\\d.]+).exe"
+    },
+    "autoupdate": {
+        "url": "https://ci.netsurf-browser.org/builds/windows/NetSurf-gcc-$version.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
Small as a mouse, fast as a cheetah and available for free. NetSurf is a multi-platform web browser for RISC OS, UNIX-like platforms (including Linux), Mac OS X, and more.