### PR TITLE
llvm-mingw: Add version 20210816

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ scoop install immuadmin immuclient immudb
 scoop install janet
 scoop install jedit
 scoop install lagrange
+scoop install llvm-mingw
 scoop install mpd
 scoop install mpg123
 scoop install netsurf
@@ -61,6 +62,7 @@ scoop install zecwallet-cli
 | [Janet](https://janet-lang.org) | Janet is a lisp-like, embeddable, functional and imperative programming language and bytecode interpreter |
 | [JEdit](http://jedit.org) | Programmer's Text Editor |
 | [Lagrange](https://github.com/skyjake/lagrange) | A desktop GUI client for browsing Geminispace |
+| [LLVM-MinGW](https://github.com/mstorsjo/llvm-mingw) | An LLVM/Clang/LLD based mingw-w64 toolchain |
 | [MPD](https://www.musicpd.org) | Famous MPD. It can play a variety of sound files while being controlled by its network protocol |
 | [Mpg123](https://www.mpg123.org) | Fast console MPEG Audio Player and decoder library |
 | [NetSurf](https://www.netsurf-browser.org) | NetSurf is a multi-platform web browser |

--- a/bucket/llvm-mingw.json
+++ b/bucket/llvm-mingw.json
@@ -1,0 +1,32 @@
+{
+    "version": "20210423",
+    "description": "An LLVM/Clang/LLD based mingw-w64 toolchain",
+    "homepage": "https://github.com/mstorsjo/llvm-mingw",
+    "license": "ISC",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mstorsjo/llvm-mingw/releases/download/20210423/llvm-mingw-20210423-msvcrt-x86_64.zip",
+            "hash": "4ab59cf2c9a035165ffd069e7fcb642629f1a9441bd9fdc10ea59862edd02537",
+            "extract_dir": "llvm-mingw-20210423-msvcrt-x86_64"
+        },
+        "32bit": {
+            "url": "https://github.com/mstorsjo/llvm-mingw/releases/download/20210423/llvm-mingw-20210423-msvcrt-i686.zip",
+            "hash": "e36eba4fc6806370c456ad83410d14c13ebdbd416d8a4da55bbcde14ad30a03f",
+            "extract_dir": "llvm-mingw-20210423-msvcrt-i686"
+        }
+    },
+    "env_add_path": "bin",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mstorsjo/llvm-mingw/releases/download/$cleanVersion/llvm-mingw-$cleanVersion-msvcrt-x86_64.zip",
+                "extract_dir": "llvm-mingw-$cleanVersion-msvcrt-x86_64"
+            },
+            "32bit": {
+                "url": "https://github.com/mstorsjo/llvm-mingw/releases/download/$cleanVersion/llvm-mingw-$cleanVersion-msvcrt-i686.zip",
+                "extract_dir": "llvm-mingw-$cleanVersion-msvcrt-i686"
+            }
+        }
+    }
+}

--- a/bucket/vlang.json
+++ b/bucket/vlang.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.4",
+    "version": "2021.38",
     "description": "The V Programming Language. Simple, fast, safe, compiled.",
     "homepage": "https://vlang.io",
     "license": "MIT",
@@ -7,14 +7,15 @@
     "suggest": {
         "An LLVM/Clang/LLD based mingw-w64 toolchain": "Scoop-littleli/llvm-mingw"
     },
-    "url": "https://github.com/vlang/v/releases/download/0.2.4/v_windows.zip",
-    "hash": "30fd4a6773f9bf55f0ef3a0aefa52df77ce6a3035836c283bb1bf5d8e6412499",
+    "url": "https://github.com/vlang/v/releases/download/weekly.2021.38/v_windows.zip",
+    "hash": "71d7b2c660b40dfbe5d0c6e9cbf2549fd6b2599055ed8ab6f8c2760c29b88f04",
     "extract_dir": "v",
     "bin": "v.exe",
     "checkver": {
-        "github": "https://github.com/vlang/v"
+        "regex": "\/releases\/tag\/weekly\\.([\\d.]+)",
+        "url": "https://github.com/vlang/v/releases/latest"
     },
     "autoupdate": {
-        "url": "https://github.com/vlang/v/releases/download/$version/v_windows.zip"
+        "url": "https://github.com/vlang/v/releases/download/weekly.$version/v_windows.zip"
     }
 }

--- a/bucket/vlang.json
+++ b/bucket/vlang.json
@@ -3,6 +3,10 @@
     "description": "The V Programming Language. Simple, fast, safe, compiled.",
     "homepage": "https://vlang.io",
     "license": "MIT",
+    "notes": "Vlang contains self-hosted TCC. For making optimized builds of your software you have to install GNU/GCC or LLVM/Clang",
+    "suggest": {
+        "An LLVM/Clang/LLD based mingw-w64 toolchain": "Scoop-littleli/llvm-mingw"
+    },
     "url": "https://github.com/vlang/v/releases/download/0.2.4/v_windows.zip",
     "hash": "30fd4a6773f9bf55f0ef3a0aefa52df77ce6a3035836c283bb1bf5d8e6412499",
     "extract_dir": "v",


### PR DESCRIPTION
Add LLVM toolchain. It actually allow vlang to successfully bootstrap.