### PR TITLE
gh-dash: Add version 4.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ scoop install difftastic
 scoop install dooble
 scoop install doom-remake4
 scoop install gemget
+scoop install gh-dash
 scoop install glazewm
 scoop install harbour
 scoop install hercules
@@ -65,6 +66,7 @@ scoop install zecwallet-cli
 | [Dooble](https://textbrowser.github.io/dooble/) | The scientific browser. Minimal, cute, and unusually stable. Completed. |
 | [Doom Remake 4](https://archive.org/details/doom_remake_4_download) | Mod compilation pack to bring Doom into the modern era |
 | [Gemget](https://github.com/makeworld-the-better-one/gemget) | Command line downloader for the Gemini protocol |
+| [Gh-dash](https://github.com/dlvhdr/gh-dash) | CLI extension to display a dashboard with pull requests and issues by filters you care about |
 | [GlazeWM](https://github.com/lars-berger/GlazeWM) | A tiling window manager for Windows inspired by i3 and Polybar |
 | [Harbour](https://harbour.github.io) | The cross-platform xBase |
 | [Hercules](https://github.com/src-d/hercules) | Acquire advanced insights from Git repository history |

--- a/bucket/gh-dash.json
+++ b/bucket/gh-dash.json
@@ -1,0 +1,38 @@
+{
+    "version": "4.7.0",
+    "description": "A beautiful CLI dashboard for GitHub",
+    "homepage": "https://github.com/dlvhdr/gh-dash/releases/download/v4.7.0/gh-dash_v4.7.0_windows-amd64.exe",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dlvhdr/gh-dash/releases/download/v4.7.0/gh-dash_v4.7.0_windows-amd64.exe#/gh-dash.exe",
+            "hash": "e3b2db3537f728729f051afeb41a55613be134a745e85cf6a1a9ac221205db26"
+        },
+        "32bit": {
+            "url": "https://github.com/dlvhdr/gh-dash/releases/download/v4.7.0/gh-dash_v4.7.0_windows-386.exe#/gh-dash.exe",
+            "hash": "e78561b6ed2a442e07c79b0bd9acbde4a40f1215eda6ccf53ff1ef94c613f066"
+        },
+        "arm64": {
+            "url": "https://github.com/dlvhdr/gh-dash/releases/download/v4.7.0/gh-dash_v4.7.0_windows-arm64.exe#/gh-dash.exe",
+            "hash": "7c5319c12db4d58f1035b8c40c6c5c09d566fd1d1788292c2339ba73eb305b32"
+        }
+    },
+    "bin": "gh-dash.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dlvhdr/gh-dash/releases/download/v$version/gh-dash_v$version_windows-amd64.exe#/gh-dash.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/dlvhdr/gh-dash/releases/download/v$version/gh-dash_v$version_windows-386.exe#/gh-dash.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/dlvhdr/gh-dash/releases/download/v$version/gh-dash_v$version_windows-arm64.exe#/gh-dash.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksum.txt"
+        }
+    }
+}

--- a/bucket/gh-dash.json
+++ b/bucket/gh-dash.json
@@ -30,9 +30,6 @@
             "arm64": {
                 "url": "https://github.com/dlvhdr/gh-dash/releases/download/v$version/gh-dash_v$version_windows-arm64.exe#/gh-dash.exe"
             }
-        },
-        "hash": {
-            "url": "$baseurl/checksum.txt"
         }
     }
 }


### PR DESCRIPTION
A GitHub (gh) CLI extension to display a dashboard with pull requests and issues by filters you care about.